### PR TITLE
12 add initial tests

### DIFF
--- a/canary_cd/__init__.py
+++ b/canary_cd/__init__.py
@@ -1,10 +1,12 @@
 __version__ = '0.0.0'
 
+import os
 from tomllib import load as toml_load
+from importlib import metadata
 
 try:
-    data = toml_load(open("pyproject.toml", "rb"))
-    __version__ = data['project']['version']
-except FileNotFoundError:
-    print("pyproject.toml not found")
-    exit(1)
+    __version__ = metadata.version('canary-cd')
+except metadata.PackageNotFoundError:
+    if os.path.isfile("pyproject.toml"):
+        data = toml_load(open("pyproject.toml", "rb"))
+        __version__ = data['project']['version']

--- a/canary_cd/routers/export.py
+++ b/canary_cd/routers/export.py
@@ -1,10 +1,12 @@
 from socket import gethostbyname
 
 from _socket import gaierror
-from fastapi import APIRouter, Request
-from sqlmodel import col
+from fastapi import APIRouter, Request, Response, HTTPException, Depends
+from fastapi.responses import JSONResponse
+from sqlmodel import select
 
-from canary_cd.dependencies import *
+from canary_cd.database import Database, Page, Redirect
+from canary_cd.settings import HTTPD
 from canary_cd.utils.httpd_conf import TraefikConfig
 
 
@@ -28,7 +30,7 @@ router = APIRouter(prefix='/export',
 
 
 @router.get('/traefik.json', summary="traefik config provider")
-async def traefik_config(request: Request, db: Database):
+async def traefik_config(db: Database) -> Response:
     tc = TraefikConfig(default_service=True)
 
     pages = db.exec(select(Page)).all()
@@ -39,4 +41,4 @@ async def traefik_config(request: Request, db: Database):
     for redirect in redirects:
         tc.add_redirect(redirect.source, redirect.destination)
 
-    return tc.render()
+    return JSONResponse(tc.render())

--- a/canary_cd/routers/project.py
+++ b/canary_cd/routers/project.py
@@ -20,8 +20,12 @@ async def project_list(db: Database,
                        filter_by: Optional[str] = '',
                        ordering: Optional[str] = 'updated_at',
                        ) -> list[ProjectDetails]:
-    query = db.query(Project).filter(column("name").contains(filter_by))
-    return query.order_by(desc(ordering)).offset(offset).limit(limit).all()
+    return db.exec(select(Project)
+                   .order_by(desc(ordering))
+                   .filter(column("name").contains(filter_by))
+                   .offset(offset)
+                   .limit(limit)
+                   ).all()
 
 
 # get project details

--- a/canary_cd/routers/project.py
+++ b/canary_cd/routers/project.py
@@ -81,7 +81,6 @@ async def project_update(name: str, data: ProjectUpdate, db: Database) -> Projec
     project_db = db.exec(select(Project).where(Project.name == name)).first()
     if not project_db:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Project not found')
-    print(data)
 
     project_data = data.model_dump(exclude_unset=True)
     project_db.sqlmodel_update(project_data)

--- a/canary_cd/utils/tasks.py
+++ b/canary_cd/utils/tasks.py
@@ -4,7 +4,7 @@ import shutil
 import tarfile
 import tempfile
 import yaml
-from asyncio.subprocess import create_subprocess_shell, PIPE
+from asyncio import subprocess
 from pathlib import Path
 
 import git
@@ -21,7 +21,7 @@ REMOTE_RE = r'^(?:(https?|git|git\+ssh|ssh):\/\/)?(?:([^@\/:]+)(?::([^@\/:]+))?@
 async def _run_cmd(cmd: str, env=None) -> tuple[str, str]:
     if env is None:
         env = {}
-    proc = await create_subprocess_shell(cmd, stdout=PIPE, stderr=PIPE, env={**os.environ, **env})
+    proc = await subprocess.create_subprocess_shell(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env={**os.environ, **env})
     stdout, stderr = await proc.communicate()
     return stdout.decode(), stderr.decode()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "coverage>=7.6.9,<8",
     "pylint>=3.3.3,<4",
     "httpx>=0.28.1,<0.29",
+    "pytest-dependency>=0.6.0",
 ]
 #
 #[tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,3 @@ dev = [
     "httpx>=0.28.1,<0.29",
     "pytest-dependency>=0.6.0",
 ]
-#
-#[tool.uv]
-#package = false

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,66 @@
+"""Main Tests"""
+from context import *
+from canary_cd.models import AuthDetails, AuthDetailsCount
+
+TEST_AUTH_SSH = {
+  "name": "example-name",
+  "auth_type": "ssh",
+  "auth_key": "ssh-ed25519 ABC"
+}
+
+TEST_AUTH_PAT = {
+  "name": "example-name",
+  "auth_type": "pat",
+  "auth_key": "gh_pat"
+}
+
+class TestAuthAPI:
+    @pytest.mark.anyio
+    @pytest.mark.dependency()
+    async def test_auth_create(self, client: AsyncClient, session: Session):
+        response = await client.post("/auth", json=TEST_AUTH_SSH)
+        assert response.status_code == 201
+        data = response.json()
+
+        for field in ['name', 'auth_type']:
+            assert data[field] == TEST_AUTH_SSH[field]
+
+        # for field in AuthDetails.model_fields.keys():
+        #     assert field in data
+
+
+    @pytest.mark.anyio
+    @pytest.mark.dependency(depends=['TestAuthAPI::test_auth_create'])
+    async def test_auth_list(self, client: AsyncClient, session: Session):
+        response = await client.get("/auth")
+        data = response.json()
+
+        assert len(data) == 1
+        for field in ['name', 'auth_type']:
+            assert data[0][field] == TEST_AUTH_SSH[field]
+
+        # for field in AuthDetails.model_fields.keys():
+        #     assert field in data[0]
+
+
+    @pytest.mark.anyio
+    @pytest.mark.dependency(depends=['TestAuthAPI::test_auth_create'])
+    async def test_auth_view(self, client: AsyncClient, session: Session):
+        response = await client.get("/auth/{}".format(TEST_AUTH_SSH['name']))
+        data = response.json()
+
+        for field in ['name', 'auth_type']:
+            assert data[field] == TEST_AUTH_SSH[field]
+
+        # for field in AuthDetails.model_fields.keys():
+        #     assert field in data
+
+        assert 'project_count' in data
+
+    @pytest.mark.anyio
+    @pytest.mark.dependency(depends=['TestAuthAPI::test_auth_list', 'TestAuthAPI::test_auth_view'])
+    async def test_auth_delete(self, client: AsyncClient, session: Session):
+        response = await client.delete("/auth/{}".format(TEST_AUTH_SSH['name']))
+        data = response.json()
+        assert response.status_code == 200
+        assert data['detail'] == '{} deleted'.format(TEST_AUTH_SSH['name'])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,44 @@
+"""Config Tests"""
+
+from context import *
+from canary_cd.models import ConfigUpdate
+
+CONFIG_KEY = 'DISCORD_WEBHOOK'
+CONFIG_VALUE = 'https://discord.com/api/webhooks/test/test'
+TEST_CONFIG = {'key': CONFIG_KEY, 'value': CONFIG_VALUE}
+
+
+class TestConfigAPI:
+    @pytest.mark.anyio
+    @pytest.mark.dependency()
+    async def test_config_create(self, client: AsyncClient, session: Session):
+        response = await client.put("/config", json=TEST_CONFIG)
+        data = response.json()
+
+        # for field in ConfigUpdate.model_fields.keys():
+        #     assert field in data
+
+        assert data['key'] == CONFIG_KEY
+        assert data['value'] == CONFIG_VALUE
+        assert response.status_code == 200
+
+    @pytest.mark.anyio
+    @pytest.mark.dependency(depends=['TestConfigAPI::test_config_create'])
+    async def test_config_list(self, client: AsyncClient, session: Session):
+        response = await client.get("/config")
+        data = response.json()
+
+        assert len(data) == 1
+        assert data[0]['key'] == CONFIG_KEY
+        assert data[0]['value'] == CONFIG_VALUE
+        # for field in ConfigUpdate.model_fields.keys():
+        #     assert field in data[0]
+
+    @pytest.mark.anyio
+    @pytest.mark.dependency(depends=['TestConfigAPI::test_config_list'])
+    async def test_config_delete(self, client: AsyncClient, session: Session):
+        response = await client.delete(f"/config/{CONFIG_KEY}")
+        data = response.json()
+
+        assert response.status_code == 200
+        assert data['detail'] == f'{CONFIG_KEY} deleted'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,13 +1,15 @@
-"""Main Test"""
+"""Main Tests"""
 from context import *
 
-def test_root(client: TestClient):
-    response = client.get("/")
+@pytest.mark.anyio
+async def test_root(client: AsyncClient, session: Session):
+    response = await client.get("/")
     assert response.status_code == 200
     assert response.json()["detail"] == "I'm a Canary!"
 
-def test_failed_auth(client: TestClient):
+@pytest.mark.anyio
+async def test_failed_auth(client: AsyncClient):
     client.headers = {}
-    response = client.get("/project/list")
+    response = await client.get("/config")
     assert response.status_code == 401
     assert response.json()["detail"] == "Not authenticated"

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -1,0 +1,94 @@
+"""Page Tests"""
+from context import *
+from canary_cd.models import PageDetails
+
+TEST_FQDN = 'example.com'
+TEST_CORS = 'https://example2.com'
+
+
+def create_page(session: Session, data: dict) -> Page:
+    page = Page(**data)
+    session.add(page)
+    session.commit()
+    session.refresh(page)
+    return page
+
+class TestPageAPI:
+    # @pytest.fixture
+    # def page(self, session: Session):
+    #     logger.debug("fixture")
+    #     page = create_page(session, {'fqdn': TEST_FQDN})
+
+    @pytest.mark.anyio
+    @pytest.mark.dependency()
+    async def test_page_create(self, client: AsyncClient, session: Session):
+        response = await client.post("/page", json={'fqdn': TEST_FQDN})
+        assert response.status_code == 201
+        data = response.json()
+        assert data['fqdn'] == TEST_FQDN
+        # for field in PageDetails.model_fields.keys():
+        #     assert field in data
+
+    @pytest.mark.anyio
+    @pytest.mark.dependency(depends=['TestPageAPI::test_page_create'])
+    async def test_page_create_already_exists(self, client: AsyncClient, session: Session):
+        response = await client.post("/page", json={'fqdn': TEST_FQDN})
+        assert response.status_code == 403
+
+    @pytest.mark.anyio
+    @pytest.mark.dependency(depends=['TestPageAPI::test_page_create'])
+    async def test_page_view(self, client: AsyncClient, session: Session):
+        response = await client.get(f"/page/{TEST_FQDN}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data['fqdn'] == TEST_FQDN
+        # for field in PageDetails.model_fields.keys():
+        #     assert field in data
+
+    @pytest.mark.anyio
+    async def test_page_does_not_exist(self, client: AsyncClient, session: Session):
+        response = await client.get(f"/page/null.com")
+        assert response.status_code == 404
+
+    @pytest.mark.anyio
+    @pytest.mark.dependency()
+    async def test_page_create_with_cors(self, client: AsyncClient, session: Session):
+        """Create a Page with a CORS Hosts"""
+        response = await client.post("/page", json={'fqdn': 'example3.com', 'cors_hosts': TEST_CORS})
+        data = response.json()
+        assert response.status_code == 201
+        assert data['fqdn'] == 'example3.com'
+        assert data['cors_hosts'] == TEST_CORS
+
+    @pytest.mark.anyio
+    @pytest.mark.dependency(depends=['TestPageAPI::test_page_create', 'TestPageAPI::test_page_create_with_cors'])
+    async def test_page_list(self, client: AsyncClient, session: Session):
+        response = await client.get('/page')
+        data = response.json()
+        assert response.status_code == 200
+        assert len(data) == 2
+        assert type(data) == list
+        # for field in PageDetails.model_fields.keys():
+        #     assert field in data[0]
+
+    @pytest.mark.anyio
+    @pytest.mark.dependency(depends=['TestPageAPI::test_page_create'])
+    async def test_page_refresh_token(self, client: AsyncClient):
+        response = await client.get(f'/page/{TEST_FQDN}/refresh-token')
+        data = response.json()
+        assert response.status_code == 200
+        assert data['token']
+        assert len(data['token']) == 64
+
+    @pytest.mark.anyio
+    @pytest.mark.dependency(depends=['TestPageAPI::test_page_create'])
+    async def test_page_delete(self, client: AsyncClient):
+        response = await client.delete(f'/page/{TEST_FQDN}')
+        data = response.json()
+        assert response.status_code == 200
+        assert data['detail'] == f'{TEST_FQDN} deleted'
+
+    @pytest.mark.anyio
+    async def test_page_delete_does_not_exist(self, client: AsyncClient):
+        response = await client.delete(f'/page/null.com')
+        assert response.status_code == 404

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,0 +1,85 @@
+"""Project Test"""
+from context import *
+from canary_cd.models import ProjectDetails
+
+TEST_NAME = "test"
+TEST_REMOTE = 'git@github.com/github/example.git'
+TEST_PROJECT = {'name': TEST_NAME, 'remote': TEST_REMOTE, 'branch': 'main'}
+
+class TestProjectAPI:
+    @pytest.mark.anyio
+    @pytest.mark.dependency()
+    async def test_project_create(self, client: AsyncClient, session: Session):
+        response = await client.post("/project", json=TEST_PROJECT)
+        data = response.json()
+        assert 'name' in data.keys()
+        assert 'remote' in data.keys()
+        assert response.status_code == 201
+
+    @pytest.mark.anyio
+    @pytest.mark.dependency(depends=['TestProjectAPI::test_project_create'])
+    async def test_project_view(self, client: AsyncClient, session: Session):
+        response = await client.get(f"/project/{TEST_NAME}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data['name'] == TEST_NAME
+        # for field, item in type(ProjectDetails).model_fields.items():
+        #     if not item.exclude:
+        #         assert field in data, f'{field} not in {data}'
+
+    @pytest.mark.anyio
+    async def test_project_does_not_exist(self, client: AsyncClient, session: Session):
+        response = await client.get(f"/project/404")
+        assert response.status_code == 404
+
+    @pytest.mark.anyio
+    @pytest.mark.dependency(depends=['TestProjectAPI::test_project_create'])
+    async def test_project_list(self, client: AsyncClient, session: Session):
+            response = await client.get('/project')
+            data = response.json()
+            assert response.status_code == 200
+            assert len(data) == 1
+            assert type(data) == list
+            # for field, item in ProjectDetails.model_fields.items():
+            #     if not item.exclude:
+            #          assert field in data[0],f'{field} not in {data[0]}'
+
+            assert 'id' in data[0]
+            assert data[0]['name'] == TEST_NAME
+            assert data[0]['remote'] == TEST_REMOTE
+            assert data[0]['branch'] == 'main'
+            assert data[0]['key'] is None
+            assert response.status_code == 200
+
+
+    @pytest.mark.anyio
+    @pytest.mark.dependency(depends=['TestProjectAPI::test_project_create'])
+    async def test_project_update(self, client: AsyncClient, session: Session):
+        response = await client.put(f'/project/{TEST_NAME}', json=TEST_PROJECT)
+        # data = response.json()
+        # assert 'name' in data.keys()
+        # assert 'remote' in data.keys()
+        # assert response.status_code == 200
+
+
+    @pytest.mark.anyio
+    @pytest.mark.dependency(depends=['TestProjectAPI::test_project_create'])
+    async def test_project_refresh_token(self, client: AsyncClient):
+        response = await client.get(f'/project/{TEST_NAME}/refresh-token')
+        data = response.json()
+        assert response.status_code == 200
+        assert data['token']
+        assert len(data['token']) == 64
+
+    @pytest.mark.anyio
+    @pytest.mark.dependency(depends=['TestProjectAPI::test_project_create'])
+    async def test_project_delete(self, client: AsyncClient):
+        response = await client.delete(f'/project/{TEST_NAME}')
+        data = response.json()
+        assert response.status_code == 200
+        assert data['detail'] == f'{TEST_NAME} deleted'
+
+    @pytest.mark.anyio
+    async def test_project_delete_does_not_exist(self, client: AsyncClient):
+        response = await client.delete(f'/project/404')
+        assert response.status_code == 404

--- a/tests/test_redirect.py
+++ b/tests/test_redirect.py
@@ -1,0 +1,48 @@
+"""Test Redirects"""
+from context import *
+from canary_cd.models import PageDetails
+from canary_cd.models import RedirectDetails
+
+TEST_SOURCE = 'example.com'
+TEST_DEST = 'www.example.com'
+
+class TestRedirectAPI:
+    @pytest.mark.anyio
+    @pytest.mark.dependency()
+    async def test_redirect_create(self, client: AsyncClient, session: Session):
+        response = await client.post("/redirect", json={'source': TEST_SOURCE, 'destination': TEST_DEST})
+        assert response.status_code == 201
+        data = response.json()
+        assert data['source'] == TEST_SOURCE
+        # for field in RedirectDetails.model_fields.keys():
+        #     assert field in data
+
+    @pytest.mark.anyio
+    @pytest.mark.dependency(depends=['TestRedirectAPI::test_redirect_create'])
+    async def test_redirect_create_already_exists(self, client: AsyncClient, session: Session):
+        response = await client.post("/redirect", json={'source': TEST_SOURCE, 'destination': TEST_DEST})
+        assert response.status_code == 403
+
+    @pytest.mark.anyio
+    @pytest.mark.dependency(depends=['TestRedirectAPI::test_redirect_create'])
+    async def test_redirect_list(self, client: AsyncClient, session: Session):
+        response = await client.get('/redirect')
+        data = response.json()
+        assert response.status_code == 200
+        assert len(data) == 1
+        assert type(data) == list
+        # for field in RedirectDetails.model_fields.keys():
+        #     assert field in data[0]
+
+    @pytest.mark.anyio
+    @pytest.mark.dependency(depends=['TestRedirectAPI::test_redirect_create'])
+    async def test_redirect_delete(self, client: AsyncClient):
+        response = await client.delete(f'/redirect/{TEST_SOURCE}')
+        data = response.json()
+        assert response.status_code == 200
+        assert data['detail'] == f'{TEST_SOURCE} deleted'
+
+    @pytest.mark.anyio
+    async def test_redirect_delete_does_not_exist(self, client: AsyncClient):
+        response = await client.delete(f'/redirect/null.com')
+        assert response.status_code == 404

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,0 +1,47 @@
+"""Project Test"""
+from context import *
+from canary_cd.models import ProjectDetails
+
+TEST_NAME = 'test-project-for-secret'
+TEST_REMOTE = 'git@github.com/github/example.git'
+TEST_PROJECT = {'name': TEST_NAME, 'remote': TEST_REMOTE, 'branch': 'main'}
+TEST_SECRET = {'key': 'KEY', 'value': 'VALUE'}
+
+class TestSecretAPI:
+    @pytest.mark.anyio
+    @pytest.mark.dependency()
+    async def test_project_create_for_secrets(self, client: AsyncClient, session: Session):
+        response = await client.post("/project", json=TEST_PROJECT)
+        data = response.json()
+        assert 'name' in data.keys()
+        assert 'remote' in data.keys()
+        assert response.status_code == 201
+
+    @pytest.mark.anyio
+    @pytest.mark.dependency(depends=['TestSecretAPI::test_project_create_for_secrets'])
+    async def test_secret_create(self, client: AsyncClient, session: Session):
+        response = await client.put(f"/secret/{TEST_NAME}", json=TEST_SECRET)
+        data = response.json()
+        assert 'key' in data.keys()
+        assert response.status_code == 200
+
+    @pytest.mark.anyio
+    @pytest.mark.dependency(depends=['TestSecretAPI::test_secret_create'])
+    async def test_secret_view(self, client: AsyncClient, session: Session):
+        response = await client.get(f"/secret/{TEST_NAME}")
+        data = response.json()
+        assert response.status_code == 200
+        assert len(data) == 1
+
+        assert 'key' in data[0].keys()
+        assert 'value' in data[0].keys()
+        assert data[0]['key'] == TEST_SECRET['key']
+        assert data[0]['value'] == TEST_SECRET['value']
+
+    @pytest.mark.anyio
+    @pytest.mark.dependency(depends=['TestSecretAPI::test_secret_create'])
+    async def test_secret_delete(self, client: AsyncClient):
+        response = await client.delete(f'/secret/{TEST_NAME}/{TEST_SECRET["key"]}')
+        data = response.json()
+        assert response.status_code == 200
+        assert data['detail'] == f'{TEST_SECRET["key"]} deleted'

--- a/uv.lock
+++ b/uv.lock
@@ -56,6 +56,7 @@ dev = [
     { name = "httpx" },
     { name = "pylint" },
     { name = "pytest" },
+    { name = "pytest-dependency" },
 ]
 
 [package.metadata]
@@ -77,6 +78,7 @@ dev = [
     { name = "httpx", specifier = ">=0.28.1,<0.29" },
     { name = "pylint", specifier = ">=3.3.3,<4" },
     { name = "pytest", specifier = ">=8.3.4,<9" },
+    { name = "pytest-dependency", specifier = ">=0.6.0" },
 ]
 
 [[package]]
@@ -630,6 +632,16 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-dependency"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/3b/317cc04e77d707d338540ca67b619df8f247f3f4c9f40e67bf5ea503ad94/pytest-dependency-0.6.0.tar.gz", hash = "sha256:934b0e6a39d95995062c193f7eaeed8a8ffa06ff1bcef4b62b0dc74a708bacc1", size = 19499, upload-time = "2023-12-31T20:38:54.991Z" }
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -702,6 +714,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258, upload-time = "2025-06-09T16:43:07.34Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847, upload-time = "2025-06-09T16:43:05.728Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "80.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- **use async client for testing**
- **update to use with async client**
- **refactor imports and list query**
- **refactor imports and response object for deletion**
- **refactor imports and response for traefik config**
- **refactor imports, query for page list and response object for page create**
- **refactor project list query**
- **remove print statement**
- **refactor import**
- **try getting version by package name, try reading project.toml when not found**
- **add pytest-dependency**
- **remove comment**
- **add initial auth tests**
- **add initial config tests**
- **add initial page tests**
- **add initial project tests**
- **add initial secrets tests**
- **add initial redirects tests**
